### PR TITLE
Fix project copy path in Dockerfile

### DIFF
--- a/src/Mahala.Api/Dockerfile
+++ b/src/Mahala.Api/Dockerfile
@@ -5,7 +5,7 @@ EXPOSE 443
 
 FROM mcr.microsoft.com/dotnet/sdk:5.0 AS build
 WORKDIR /src
-COPY ["src/Mahala.Api/Mahala.Api.csproj", "src/Mahala.Api/"]
+COPY ["src/Mahala.Api/Mahala.Api.csproj", "Mahala.Api/"]
 RUN dotnet restore "src/Mahala.Api/Mahala.Api.csproj"
 COPY . .
 WORKDIR "/src/Mahala.Api"

--- a/src/Mahala.Api/Dockerfile
+++ b/src/Mahala.Api/Dockerfile
@@ -5,8 +5,8 @@ EXPOSE 443
 
 FROM mcr.microsoft.com/dotnet/sdk:5.0 AS build
 WORKDIR /src
-COPY ["Mahala.Api/Mahala.Api.csproj", "Mahala.Api/"]
-RUN dotnet restore "Mahala.Api/Mahala.Api.csproj"
+COPY ["src/Mahala.Api/Mahala.Api.csproj", "src/Mahala.Api/"]
+RUN dotnet restore "src/Mahala.Api/Mahala.Api.csproj"
 COPY . .
 WORKDIR "/src/Mahala.Api"
 RUN dotnet build "Mahala.Api.csproj" -c Release -o /app/build


### PR DESCRIPTION
## Summary
- correct project path in Dockerfile so Docker builds succeed

## Testing
- `dotnet build src/Mahala.sln -c Release` *(fails: `dotnet: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_686fc726e330832290e61dfd612e77cc