### PR TITLE
Fix project path in Dockerfile

### DIFF
--- a/src/Mahala.Api/Dockerfile
+++ b/src/Mahala.Api/Dockerfile
@@ -5,7 +5,7 @@ EXPOSE 443
 
 FROM mcr.microsoft.com/dotnet/sdk:5.0 AS build
 WORKDIR /src
-COPY ["Mahala.Api/Mahala.Api.csproj", "Mahala.Api/"]
+COPY ["src/Mahala.Api/Mahala.Api.csproj", "Mahala.Api/"]
 RUN dotnet restore "Mahala.Api/Mahala.Api.csproj"
 COPY . .
 WORKDIR "/src/Mahala.Api"


### PR DESCRIPTION
## Summary
- ensure the Dockerfile copies and restores the project to `Mahala.Api/` inside the build container

## Testing
- `dotnet build src/Mahala.sln -c Release` *(fails: `dotnet: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_686fc726e330832290e61dfd612e77cc